### PR TITLE
Add RTSP stream paths for discovery (Armcrest)

### DIFF
--- a/CamXploit.py
+++ b/CamXploit.py
@@ -870,6 +870,9 @@ def detect_live_streams(ip, open_ports):
             '/live/1/h264.sdp',  # Generic
             '/live/1/mpeg4.sdp',  # Generic
             '/live/1/audio.sdp'  # Generic
+            '/cam/realmonitor?channel=1&subtype=0',  # Amcrest (Main Stream)
+            '/cam/realmonitor?channel=1&subtype=1',  # Amcrest (Sub Stream)
+            '/h264Preview_01_main' #Armcrest DVR/NVR
         ],
         'rtmp': [
             '/live',


### PR DESCRIPTION
- Added /cam/realmonitor for IP camera streams.
- Added /h264Preview_01_main for DVR/NVR streams.

<img width="1190" height="834" alt="Pull" src="https://github.com/user-attachments/assets/bbe213e1-2158-4e48-a137-b77ad3b86fc7" />
